### PR TITLE
fix: Missing Rule Details - Ensure i18n always initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+ - Ensure i18n resources are always initialized.
+
 ## [1.1.0] - 2021-09-16
  - Scan rule for uploading:
  	- HTACCESS file

--- a/src/main/java/org/sasanlabs/fileupload/ExtensionFileUpload.java
+++ b/src/main/java/org/sasanlabs/fileupload/ExtensionFileUpload.java
@@ -29,6 +29,10 @@ public class ExtensionFileUpload extends ExtensionAdaptor {
 
     protected static final Logger LOGGER = LogManager.getLogger(ExtensionFileUpload.class);
 
+    static {
+        FileUploadI18n.init();
+    }
+
     @Override
     public String getAuthor() {
         return "KSASAN preetkaran20@gmail.com";
@@ -36,7 +40,6 @@ public class ExtensionFileUpload extends ExtensionAdaptor {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        FileUploadI18n.init();
         super.hook(extensionHook);
         if (hasView()) {
             extensionHook.getHookView().addOptionPanel(new FileUploadOptionsPanel());


### PR DESCRIPTION
Fixes SasanLabs/owasp-zap-fileupload-addon#17

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>