### PR TITLE
Feature: Disable stoping of addon after finding vulnerability

### DIFF
--- a/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
+++ b/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
@@ -72,16 +72,14 @@ public class FileUploadAttackExecutor {
 
     public boolean executeAttack() throws FileUploadException {
 
-        Boolean shouldSendRequestsAfterFindingVulnerability = FileUploadConfiguration
-                .getInstance()
-                .getSendRequestsAfterFindingVulnerability();
+        Boolean shouldSendRequestsAfterFindingVulnerability =
+                FileUploadConfiguration.getInstance().getSendRequestsAfterFindingVulnerability();
 
         for (AttackVector attackVector : attackVectors) {
             if (this.fileUploadScanRule.isStop()) {
                 return false;
             } else {
-                if (attackVector.execute(this) &&
-                        !shouldSendRequestsAfterFindingVulnerability) {
+                if (attackVector.execute(this) && !shouldSendRequestsAfterFindingVulnerability) {
                     return true;
                 }
             }

--- a/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
+++ b/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
@@ -29,6 +29,7 @@ import org.sasanlabs.fileupload.attacks.rce.php.ImageWithPHPSnippetFileUpload;
 import org.sasanlabs.fileupload.attacks.rce.php.SimplePHPFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.HtmlFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.SVGFileUpload;
+import org.sasanlabs.fileupload.configuration.FileUploadConfiguration;
 import org.sasanlabs.fileupload.exception.FileUploadException;
 
 /**
@@ -70,11 +71,17 @@ public class FileUploadAttackExecutor {
     }
 
     public boolean executeAttack() throws FileUploadException {
+
+        Boolean shouldSendRequestsAfterFindingVulnerability = FileUploadConfiguration
+                .getInstance()
+                .getSendRequestsAfterFindingVulnerability();
+
         for (AttackVector attackVector : attackVectors) {
             if (this.fileUploadScanRule.isStop()) {
                 return false;
             } else {
-                if (attackVector.execute(this)) {
+                if (attackVector.execute(this) &&
+                        !shouldSendRequestsAfterFindingVulnerability) {
                     return true;
                 }
             }

--- a/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
+++ b/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 SasanLabs
+ * Copyright 2023 SasanLabs
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import org.sasanlabs.fileupload.attacks.rce.php.ImageWithPHPSnippetFileUpload;
 import org.sasanlabs.fileupload.attacks.rce.php.SimplePHPFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.HtmlFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.SVGFileUpload;
+import org.sasanlabs.fileupload.configuration.FileUploadConfiguration;
 import org.sasanlabs.fileupload.exception.FileUploadException;
 
 /**
@@ -70,8 +71,13 @@ public class FileUploadAttackExecutor {
     }
 
     public boolean executeAttack() throws FileUploadException {
+        Boolean shouldSendRequestsAfterFindingVulnerability = FileUploadConfiguration
+                .getInstance()
+                .getSendRequestsAfterFindingVulnerability();
+
         for (AttackVector attackVector : attackVectors) {
-            if (this.fileUploadScanRule.isStop()) {
+            if (!shouldSendRequestsAfterFindingVulnerability &&
+                    this.fileUploadScanRule.isStop()) {
                 return false;
             } else {
                 if (attackVector.execute(this)) {

--- a/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
+++ b/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
@@ -29,7 +29,6 @@ import org.sasanlabs.fileupload.attacks.rce.php.ImageWithPHPSnippetFileUpload;
 import org.sasanlabs.fileupload.attacks.rce.php.SimplePHPFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.HtmlFileUpload;
 import org.sasanlabs.fileupload.attacks.xss.SVGFileUpload;
-import org.sasanlabs.fileupload.configuration.FileUploadConfiguration;
 import org.sasanlabs.fileupload.exception.FileUploadException;
 
 /**
@@ -71,13 +70,8 @@ public class FileUploadAttackExecutor {
     }
 
     public boolean executeAttack() throws FileUploadException {
-        Boolean shouldSendRequestsAfterFindingVulnerability = FileUploadConfiguration
-                .getInstance()
-                .getSendRequestsAfterFindingVulnerability();
-
         for (AttackVector attackVector : attackVectors) {
-            if (!shouldSendRequestsAfterFindingVulnerability &&
-                    this.fileUploadScanRule.isStop()) {
+            if (this.fileUploadScanRule.isStop()) {
                 return false;
             } else {
                 if (attackVector.execute(this)) {

--- a/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
+++ b/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
@@ -109,6 +109,10 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
                         parseResponseEndIdentifier);
     }
 
+    public Boolean getSendRequestsAfterFindingVulnerability() {
+        return sendRequestsAfterFindingVulnerability;
+    }
+
     public void setSendRequestsAfterFindingVulnerability(boolean shouldSendRequestsAfterFindingVulnerability) {
         sendRequestsAfterFindingVulnerability = shouldSendRequestsAfterFindingVulnerability;
         this.getConfig()

--- a/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
+++ b/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 SasanLabs
+ * Copyright 2023 SasanLabs
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -39,11 +39,15 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
             PARAM_BASE_KEY + ".parseresponse.startidentifier";
     private static final String PARAM_PARSE_RESPONSE_CONFIGURATION_END_IDENTIFIER =
             PARAM_BASE_KEY + ".parseresponse.endidentifier";
+    private static final String PARAM_SEND_REQUESTS_AFTER_FINDING_VULNERABILITY_IDENTIFIER =
+            PARAM_BASE_KEY + ".sendrequests";
 
     private String staticLocationURIRegex;
     private String dynamicLocationURIRegex;
     private String parseResponseStartIdentifier;
     private String parseResponseEndIdentifier;
+
+    private Boolean sendRequestsAfterFindingVulnerability;
 
     private static volatile FileUploadConfiguration fileUploadConfiguration;
 
@@ -105,6 +109,14 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
                         parseResponseEndIdentifier);
     }
 
+    public void setSendRequestsAfterFindingVulnerability(boolean shouldSendRequestsAfterFindingVulnerability) {
+        sendRequestsAfterFindingVulnerability = shouldSendRequestsAfterFindingVulnerability;
+        this.getConfig()
+                .setProperty(
+                        PARAM_SEND_REQUESTS_AFTER_FINDING_VULNERABILITY_IDENTIFIER,
+                        shouldSendRequestsAfterFindingVulnerability);
+    }
+
     @Override
     protected String getConfigVersionKey() {
         return CONFIG_VERSION_KEY;
@@ -125,6 +137,8 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
                 getConfig().getString(PARAM_PARSE_RESPONSE_CONFIGURATION_START_IDENTIFIER));
         this.setParseResponseEndIdentifier(
                 getConfig().getString(PARAM_PARSE_RESPONSE_CONFIGURATION_END_IDENTIFIER));
+        this.setSendRequestsAfterFindingVulnerability(
+                getConfig().getBoolean(PARAM_SEND_REQUESTS_AFTER_FINDING_VULNERABILITY_IDENTIFIER));
     }
 
     @Override

--- a/src/main/java/org/sasanlabs/fileupload/i18n/FileUploadI18n.java
+++ b/src/main/java/org/sasanlabs/fileupload/i18n/FileUploadI18n.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 SasanLabs
+ * Copyright 2023 SasanLabs
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -81,7 +81,9 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
 
     private JCheckBox buildSendRequestsAfterFindingVulnerabilityCheckbox() {
         sendRequestsAfterFindingVulnerability =
-                new JCheckBox(FileUploadI18n.getMessage("fileupload.settings.checkbox.sendrequestsaftervulnerability"));
+                new JCheckBox(
+                        FileUploadI18n.getMessage(
+                                "fileupload.settings.checkbox.sendrequestsaftervulnerability"));
         sendRequestsAfterFindingVulnerability.setSelected(false);
         return sendRequestsAfterFindingVulnerability;
     }

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 SasanLabs
+ * Copyright 2023 SasanLabs
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -52,6 +53,8 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
     private JTextField parseResponseStartIdentifier;
     private JTextField parseResponseEndIdentifier;
 
+    private JCheckBox sendRequestsAfterFindingVulnerability;
+
     public FileUploadOptionsPanel() {
         super();
         this.setName(FileUploadI18n.getMessage("fileupload.settings.title"));
@@ -72,7 +75,14 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
 
     private void init(JPanel settingsPanel) {
         settingsPanel.add(uriLocatorConfiguration());
+        settingsPanel.add(buildSendRequestsAfterFindingVulnerabilityCheckbox());
         footerPanel.add(getResetButton());
+    }
+
+    private JCheckBox buildSendRequestsAfterFindingVulnerabilityCheckbox() {
+        sendRequestsAfterFindingVulnerability =
+                new JCheckBox("Continue Sending Requests After Vulnerability Reported");
+        return sendRequestsAfterFindingVulnerability;
     }
 
     private JButton getResetButton() {

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -88,8 +88,8 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
                                 "fileupload.settings.checkbox.sendrequestsaftervulnerability"));
 
         sendRequestsAfterFindingVulnerability = new JCheckBox();
-        sendRequestsAfterFindingVulnerabilityLabel.add(sendRequestsAfterFindingVulnerability);
         sendRequestsAfterFindingVulnerabilityPanel.add(sendRequestsAfterFindingVulnerabilityLabel);
+        sendRequestsAfterFindingVulnerabilityPanel.add(sendRequestsAfterFindingVulnerability);
 
         return sendRequestsAfterFindingVulnerabilityPanel;
     }

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -82,6 +82,7 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
     private JCheckBox buildSendRequestsAfterFindingVulnerabilityCheckbox() {
         sendRequestsAfterFindingVulnerability =
                 new JCheckBox("Continue Sending Requests After Vulnerability Reported");
+        sendRequestsAfterFindingVulnerability.setSelected(false);
         return sendRequestsAfterFindingVulnerability;
     }
 
@@ -235,6 +236,7 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
         dynamicLocationConfigurationURIRegex.setText("");
         parseResponseStartIdentifier.setText("");
         parseResponseEndIdentifier.setText("");
+        sendRequestsAfterFindingVulnerability.setSelected(false);
     }
 
     @Override

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -79,13 +79,17 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
         footerPanel.add(getResetButton());
     }
 
-    private JCheckBox buildSendRequestsAfterFindingVulnerabilityCheckbox() {
-        sendRequestsAfterFindingVulnerability =
-                new JCheckBox(
+    private JLabel buildSendRequestsAfterFindingVulnerabilityCheckbox() {
+        JLabel label =
+                new JLabel(
                         FileUploadI18n.getMessage(
                                 "fileupload.settings.checkbox.sendrequestsaftervulnerability"));
-        sendRequestsAfterFindingVulnerability.setSelected(false);
-        return sendRequestsAfterFindingVulnerability;
+
+        sendRequestsAfterFindingVulnerability = new JCheckBox();
+
+        label.add(sendRequestsAfterFindingVulnerability);
+
+        return label;
     }
 
     private JButton getResetButton() {

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -81,7 +81,7 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
 
     private JCheckBox buildSendRequestsAfterFindingVulnerabilityCheckbox() {
         sendRequestsAfterFindingVulnerability =
-                new JCheckBox("Continue Sending Requests After Vulnerability Reported");
+                new JCheckBox(FileUploadI18n.getMessage("fileupload.settings.checkbox.sendrequestsaftervulnerability"));
         sendRequestsAfterFindingVulnerability.setSelected(false);
         return sendRequestsAfterFindingVulnerability;
     }

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -251,6 +251,8 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
         parseResponseStartIdentifier.setText(
                 fileUploadConfiguration.getParseResponseStartIdentifier());
         parseResponseEndIdentifier.setText(fileUploadConfiguration.getParseResponseEndIdentifier());
+        sendRequestsAfterFindingVulnerability.setSelected(
+                fileUploadConfiguration.getSendRequestsAfterFindingVulnerability());
     }
 
     @Override

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -287,7 +287,7 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void saveParam(Object optionParams) throws Exception {
+    public void saveParam(Object optionParams) {
         FileUploadConfiguration fileUploadConfiguration =
                 ((OptionsParam) optionParams).getParamSet(FileUploadConfiguration.class);
         fileUploadConfiguration.setStaticLocationURIRegex(

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -80,16 +80,15 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
     }
 
     private JLabel buildSendRequestsAfterFindingVulnerabilityCheckbox() {
-        JLabel label =
+        JLabel SendRequestsAfterFindingVulnerabilityLabel =
                 new JLabel(
                         FileUploadI18n.getMessage(
                                 "fileupload.settings.checkbox.sendrequestsaftervulnerability"));
 
         sendRequestsAfterFindingVulnerability = new JCheckBox();
+        SendRequestsAfterFindingVulnerabilityLabel.add(sendRequestsAfterFindingVulnerability);
 
-        label.add(sendRequestsAfterFindingVulnerability);
-
-        return label;
+        return SendRequestsAfterFindingVulnerabilityLabel;
     }
 
     private JButton getResetButton() {

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -79,16 +79,19 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
         footerPanel.add(getResetButton());
     }
 
-    private JLabel buildSendRequestsAfterFindingVulnerabilityCheckbox() {
-        JLabel SendRequestsAfterFindingVulnerabilityLabel =
+    private JPanel buildSendRequestsAfterFindingVulnerabilityCheckbox() {
+        JPanel sendRequestsAfterFindingVulnerabilityPanel = new JPanel();
+        sendRequestsAfterFindingVulnerabilityPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
+        JLabel sendRequestsAfterFindingVulnerabilityLabel =
                 new JLabel(
                         FileUploadI18n.getMessage(
                                 "fileupload.settings.checkbox.sendrequestsaftervulnerability"));
 
         sendRequestsAfterFindingVulnerability = new JCheckBox();
-        SendRequestsAfterFindingVulnerabilityLabel.add(sendRequestsAfterFindingVulnerability);
+        sendRequestsAfterFindingVulnerabilityLabel.add(sendRequestsAfterFindingVulnerability);
+        sendRequestsAfterFindingVulnerabilityPanel.add(sendRequestsAfterFindingVulnerabilityLabel);
 
-        return SendRequestsAfterFindingVulnerabilityLabel;
+        return sendRequestsAfterFindingVulnerabilityPanel;
     }
 
     private JButton getResetButton() {

--- a/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
+++ b/src/main/java/org/sasanlabs/fileupload/ui/FileUploadOptionsPanel.java
@@ -298,5 +298,7 @@ public class FileUploadOptionsPanel extends AbstractParamPanel {
                 this.parseResponseStartIdentifier.getText());
         fileUploadConfiguration.setParseResponseEndIdentifier(
                 this.parseResponseEndIdentifier.getText());
+        fileUploadConfiguration.setSendRequestsAfterFindingVulnerability(
+                this.sendRequestsAfterFindingVulnerability.isSelected());
     }
 }

--- a/src/main/resources/org/sasanlabs/fileupload/i18n/Messages.properties
+++ b/src/main/resources/org/sasanlabs/fileupload/i18n/Messages.properties
@@ -127,4 +127,4 @@ fileupload.scanner.vulnerability.htaccessFile.soln=Follow the suggestions mentio
 3. https://www.youtube.com/watch?v=CmF9sEyKZNo \
 4. https://cwe.mitre.org/data/definitions/434.html
 
-fileupload.settings.checkbox.sendrequestsaftervulnerability=Continue Sending Requests After Vulnerability Reported
+fileupload.settings.checkbox.sendrequestsaftervulnerability=Keep exploiting after discovery

--- a/src/main/resources/org/sasanlabs/fileupload/i18n/Messages.properties
+++ b/src/main/resources/org/sasanlabs/fileupload/i18n/Messages.properties
@@ -126,3 +126,5 @@ fileupload.scanner.vulnerability.htaccessFile.soln=Follow the suggestions mentio
 2. https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload \
 3. https://www.youtube.com/watch?v=CmF9sEyKZNo \
 4. https://cwe.mitre.org/data/definitions/434.html
+
+fileupload.settings.checkbox.sendrequestsaftervulnerability=Continue Sending Requests After Vulnerability Reported


### PR DESCRIPTION
Fixes #19 

- Added UI (checkbox) to allow users to choose to keep the uploading files after a vulnerability is found
- Added logic to set/get this flag in configurations and in other places
- Modified condition inside FileUploadAttackExecutor to consider this flag
