### PR TITLE
Fix exceptions with newer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
+### Fixed
+- Fix exceptions using option introduced in previous version.
 
 ## [1.2.0] - 2023-10-19
  - Ensure i18n resources are always initialized.

--- a/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
+++ b/src/main/java/org/sasanlabs/fileupload/attacks/FileUploadAttackExecutor.java
@@ -72,7 +72,7 @@ public class FileUploadAttackExecutor {
 
     public boolean executeAttack() throws FileUploadException {
 
-        Boolean shouldSendRequestsAfterFindingVulnerability =
+        boolean shouldSendRequestsAfterFindingVulnerability =
                 FileUploadConfiguration.getInstance().getSendRequestsAfterFindingVulnerability();
 
         for (AttackVector attackVector : attackVectors) {

--- a/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
+++ b/src/main/java/org/sasanlabs/fileupload/configuration/FileUploadConfiguration.java
@@ -47,7 +47,7 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
     private String parseResponseStartIdentifier;
     private String parseResponseEndIdentifier;
 
-    private Boolean sendRequestsAfterFindingVulnerability;
+    private boolean sendRequestsAfterFindingVulnerability;
 
     private static volatile FileUploadConfiguration fileUploadConfiguration;
 
@@ -109,7 +109,7 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
                         parseResponseEndIdentifier);
     }
 
-    public Boolean getSendRequestsAfterFindingVulnerability() {
+    public boolean getSendRequestsAfterFindingVulnerability() {
         return sendRequestsAfterFindingVulnerability;
     }
 
@@ -142,7 +142,7 @@ public class FileUploadConfiguration extends VersionedAbstractParam {
         this.setParseResponseEndIdentifier(
                 getConfig().getString(PARAM_PARSE_RESPONSE_CONFIGURATION_END_IDENTIFIER));
         this.setSendRequestsAfterFindingVulnerability(
-                getConfig().getBoolean(PARAM_SEND_REQUESTS_AFTER_FINDING_VULNERABILITY_IDENTIFIER));
+                getBoolean(PARAM_SEND_REQUESTS_AFTER_FINDING_VULNERABILITY_IDENTIFIER, false));
     }
 
     @Override


### PR DESCRIPTION
Load the option with the method that defaults to a given value when it does not exist, otherwise this will lead to `NoSuchElementException` until the option is set.
Also, use the primitive boolean which is the most appropriate type and prevents `NullPointerException`s as it was null by default.

---
e.g.
```
[ZAP-BootstrapGUI] ERROR org.parosproxy.paros.common.AbstractParam - 'fileupload.sendrequests' doesn't map to an existing object
java.util.NoSuchElementException: 'fileupload.sendrequests' doesn't map to an existing object
	at org.apache.commons.configuration.AbstractConfiguration.getBoolean(AbstractConfiguration.java:644) ~[commons-configuration-1.10.jar:1.10]
	at org.sasanlabs.fileupload.configuration.FileUploadConfiguration.parseImpl(FileUploadConfiguration.java:146) ~[?:?]
	at org.zaproxy.zap.common.VersionedAbstractParam.parse(VersionedAbstractParam.java:76) ~[main/:?]
	at org.parosproxy.paros.common.AbstractParam.load(AbstractParam.java:68) [main/:?]
```

```
[AWT-EventQueue-0] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "AWT-EventQueue-0"
java.lang.NullPointerException: null
	at org.sasanlabs.fileupload.ui.FileUploadOptionsPanel.initParam(FileUploadOptionsPanel.java:263) ~[?:?]
	at org.parosproxy.paros.view.AbstractParamContainerPanel.lambda$1(AbstractParamContainerPanel.java:662) ~[main/:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at org.parosproxy.paros.view.AbstractParamContainerPanel.initParam(AbstractParamContainerPanel.java:662) ~[main/:?]
```