### PR TITLE
Add info URL to the add-on manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
+- Add info URL to the add-on manifest.
 
 ## [1.2.1] - 2023-10-20
 - Fix exceptions using option introduced in previous version.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ zapAddOn {
     manifest {
         author.set("KSASAN preetkaran20@gmail.com")
         repo.set("https://github.com/SasanLabs/owasp-zap-fileupload-addon/")
+        url.set("https://www.zaproxy.org/blog/2021-08-20-zap-fileupload-addon/")
     }
 }
 


### PR DESCRIPTION
Link to the blog post for the user to know more about the add-on.